### PR TITLE
Add eclipse-platform-committers team as security-managers

### DIFF
--- a/otterdog/eclipse-platform.jsonnet
+++ b/otterdog/eclipse-platform.jsonnet
@@ -16,6 +16,9 @@ orgs.newOrg('eclipse-platform') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
+    security_managers+: [
+      "eclipse-platform-committers"
+    ],
     twitter_username: "EclipseJavaIDE",
     two_factor_requirement: false,
     web_commit_signoff_required: false,


### PR DESCRIPTION
Related to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3411.