### PR TITLE
Prevent opening new issues for eclipse.platform.releng repo

### DIFF
--- a/otterdog/eclipse-platform.jsonnet
+++ b/otterdog/eclipse-platform.jsonnet
@@ -159,6 +159,7 @@ orgs.newOrg('eclipse-platform') {
       dependabot_alerts_enabled: false,
       has_discussions: true,
       has_projects: false,
+      has_issues: false,
       has_wiki: false,
       web_commit_signoff_required: false,
       workflows+: {


### PR DESCRIPTION
As the repo has been merged into eclipse.platform.releng.aggregator one having new issues in this repo is plain confusing.