### PR TITLE
Update to allow_auto_merge for eclipse.platform.releng.aggregator

### DIFF
--- a/otterdog/eclipse-platform.jsonnet
+++ b/otterdog/eclipse-platform.jsonnet
@@ -175,6 +175,7 @@ orgs.newOrg('eclipse-platform') {
       ],
     },
     orgs.newRepo('eclipse.platform.releng.aggregator') {
+      allow_auto_merge: true,
       default_branch: "master",
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,


### PR DESCRIPTION
@akurtakov 

Updating the target platform will be easier if I can enable auto merge to complete the processing automatically if the verification build passes.

I think this change requires team lead approval so please indicate your approval assuming that you do.