### PR TITLE
Remove unnecessary repository webhooks to RelEng JIPP

### DIFF
--- a/otterdog/eclipse-platform.jsonnet
+++ b/otterdog/eclipse-platform.jsonnet
@@ -201,14 +201,6 @@ orgs.newOrg('eclipse.platform', 'eclipse-platform') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      webhooks: [
-        orgs.newRepoWebhook('https://ci.eclipse.org/releng/github-webhook/') {
-          content_type: "json",
-          events+: [
-            "push"
-          ],
-        },
-      ],
       secrets: [
         orgs.newRepoSecret('ECLIPSE_GITLAB_API_TOKEN') {
           value: "pass:bots/eclipse.platform.releng/gitlab.eclipse.org/api-token",
@@ -557,14 +549,6 @@ orgs.newOrg('eclipse.platform', 'eclipse-platform') {
       workflows+: {
         default_workflow_permissions: "read",
       },
-      webhooks: [
-        orgs.newRepoWebhook('https://ci.eclipse.org/releng/github-webhook/') {
-          content_type: "json",
-          events+: [
-            "push"
-          ],
-        },
-      ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master') {
           required_approving_review_count: 0,
@@ -583,14 +567,6 @@ orgs.newOrg('eclipse.platform', 'eclipse-platform') {
       workflows+: {
         enabled: false,
       },
-      webhooks: [
-        orgs.newRepoWebhook('https://ci.eclipse.org/releng/github-webhook/') {
-          content_type: "json",
-          events+: [
-            "push"
-          ],
-        },
-      ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master') {
           required_approving_review_count: 0,


### PR DESCRIPTION
Except for the eclipse.platform.swt repository, which is hosted at the Releng JIPP for the native build agents (https://ci.eclipse.org/releng/job/eclipse.platform.swt/), none of the eclipse.platform repositories seems to need a webhook into the Releng JIPP.

@fredg02 or did I miss something? From the git-blame I couldn't derive a reason, why these extra hooks exists (besides the orga's webhook into the platform JIPP).