### PR TITLE
Archive eclipse.platform.images repository

### DIFF
--- a/otterdog/eclipse-platform.jsonnet
+++ b/otterdog/eclipse-platform.jsonnet
@@ -130,6 +130,7 @@ orgs.newOrg('eclipse.platform', 'eclipse-platform') {
       ],
     },
     orgs.newRepo('eclipse.platform.images') {
+      archived: true,
       default_branch: "master",
       allow_squash_merge: false,
       delete_branch_on_merge: true,


### PR DESCRIPTION
This archives the `eclipse.platform.images` repository as most of its use cases became obsolete because of SVG support inside Eclipse SWT and the embedding of SVGs into the actual bundles.

According to:
- https://github.com/eclipse-platform/eclipse.platform.images/issues/152
- https://github.com/eclipse-platform/eclipse.platform.images/pull/156
- https://www.eclipse.org/lists/platform-dev/msg04170.html